### PR TITLE
Fix dashboard card update delays

### DIFF
--- a/src/components/Expenses.tsx
+++ b/src/components/Expenses.tsx
@@ -533,6 +533,9 @@ const Expenses: React.FC = () => {
                     return false;
                   }
                 }
+
+                // Nothing excluded this transaction, include it
+                return true;
               })
               .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
               .map((transaction) => (

--- a/src/components/auth/OnboardingFlow.tsx
+++ b/src/components/auth/OnboardingFlow.tsx
@@ -245,10 +245,10 @@ const OnboardingFlow: React.FC = () => {
         supabaseAnonKey: import.meta.env.VITE_SUPABASE_ANON_KEY ? 'SET' : 'NOT SET'
       });
       
-      // Set a shorter timeout to prevent infinite loading
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Onboarding timeout - please try again')), 15000); // 15 second timeout
-      });
+       // Increase timeout to 30 seconds to prevent premature timeouts on slow connections.
+       const timeoutPromise = new Promise((_, reject) => {
+         setTimeout(() => reject(new Error('Onboarding timeout - please try again')), 30000);
+       });
       
       const monthlyIncome = parseFloat(formData.monthly_income) || 0;
       

--- a/src/hooks/useDashboardConfig.ts
+++ b/src/hooks/useDashboardConfig.ts
@@ -317,9 +317,22 @@ export const useDashboardConfig = (userId: string) => {
 
     console.log('📊 Adding card to dashboard:', cardType, 'Updated config:', updatedConfig);
 
-    // Save the updated configuration
+    // Update local state immediately so the UI reflects the change before
+    // persisting to the database. Without this, the added card does not
+    // appear until a reload.
+    setCurrentConfig(updatedConfig);
+    setConfigurations(prev => {
+      const idx = prev.findIndex(cfg => cfg.id === updatedConfig.id);
+      if (idx !== -1) {
+        const arr = [...prev];
+        arr[idx] = updatedConfig;
+        return arr;
+      }
+      return [...prev, updatedConfig];
+    });
+    // Persist to the database
     await saveConfiguration(updatedConfig);
-    
+
     console.log('✅ Card added successfully:', cardType);
   }, [currentConfig, saveConfiguration, userId]);
 
@@ -336,6 +349,18 @@ export const useDashboardConfig = (userId: string) => {
       updatedAt: new Date().toISOString()
     };
 
+    // Immediately update local state to remove the card
+    setCurrentConfig(updatedConfig);
+    setConfigurations(prev => {
+      const idx = prev.findIndex(cfg => cfg.id === updatedConfig.id);
+      if (idx !== -1) {
+        const arr = [...prev];
+        arr[idx] = updatedConfig;
+        return arr;
+      }
+      return [...prev, updatedConfig];
+    });
+
     await saveConfiguration(updatedConfig);
   }, [currentConfig, saveConfiguration]);
 
@@ -347,12 +372,24 @@ export const useDashboardConfig = (userId: string) => {
       ...currentConfig,
       layoutConfig: {
         ...currentConfig.layoutConfig,
-        cards: currentConfig.layoutConfig.cards.map(card => 
+        cards: currentConfig.layoutConfig.cards.map(card =>
           card.id === cardId ? { ...card, ...updates } : card
         )
       },
       updatedAt: new Date().toISOString()
     };
+
+    // Update local state so changes are reflected immediately
+    setCurrentConfig(updatedConfig);
+    setConfigurations(prev => {
+      const idx = prev.findIndex(cfg => cfg.id === updatedConfig.id);
+      if (idx !== -1) {
+        const arr = [...prev];
+        arr[idx] = updatedConfig;
+        return arr;
+      }
+      return [...prev, updatedConfig];
+    });
 
     await saveConfiguration(updatedConfig);
   }, [currentConfig, saveConfiguration]);
@@ -365,12 +402,24 @@ export const useDashboardConfig = (userId: string) => {
       ...currentConfig,
       layoutConfig: {
         ...currentConfig.layoutConfig,
-        cards: currentConfig.layoutConfig.cards.map(card => 
+        cards: currentConfig.layoutConfig.cards.map(card =>
           card.id === cardId ? { ...card, size: newSize } : card
         )
       },
       updatedAt: new Date().toISOString()
     };
+
+    // Update local state so resize is visible immediately
+    setCurrentConfig(updatedConfig);
+    setConfigurations(prev => {
+      const idx = prev.findIndex(cfg => cfg.id === updatedConfig.id);
+      if (idx !== -1) {
+        const arr = [...prev];
+        arr[idx] = updatedConfig;
+        return arr;
+      }
+      return [...prev, updatedConfig];
+    });
 
     await saveConfiguration(updatedConfig);
   }, [currentConfig, saveConfiguration]);
@@ -411,7 +460,17 @@ export const useDashboardConfig = (userId: string) => {
 
     console.log('📊 Adding multiple cards to dashboard:', cardTypes, 'Updated config:', updatedConfig);
 
-    // Save the updated configuration
+    // Update local state so all cards appear immediately
+    setCurrentConfig(updatedConfig);
+    setConfigurations(prev => {
+      const idx = prev.findIndex(cfg => cfg.id === updatedConfig.id);
+      if (idx !== -1) {
+        const arr = [...prev];
+        arr[idx] = updatedConfig;
+        return arr;
+      }
+      return [...prev, updatedConfig];
+    });
     await saveConfiguration(updatedConfig);
     
     console.log('✅ Multiple cards added successfully:', cardTypes.length);


### PR DESCRIPTION
## Summary
- update dashboard card hooks to modify local state before saving
- fix expenses list filter to include all matching items
- extend onboarding timeout to 30s

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835de5c68c832ab7d1039540ed20e7