### PR TITLE
Rename BudgetTracker to Nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-budgeter
+Nudge

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# 🔧 BudgetTracker Setup Guide
+# 🔧 Nudge Setup Guide
 
 ## 🔐 Supabase Configuration
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,4 +1,4 @@
-# 🚀 **BudgetTracker Setup Guide**
+# 🚀 **Nudge Setup Guide**
 
 ## **🚨 Critical Issue: Database Not Connected**
 
@@ -25,7 +25,7 @@ If you just want to test the dashboard immediately:
 3. Click "New Project"
 4. Choose your organization
 5. Fill in:
-   - **Name**: `BudgetTracker` (or your preferred name)
+   - **Name**: `Nudge` (or your preferred name)
    - **Database Password**: Create a strong password
    - **Region**: Choose closest to your users
 6. Click "Create new project"
@@ -264,4 +264,4 @@ ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
 - [ ] Dashboard loads with default cards
 - [ ] Can add/edit accounts, assets, goals
 
-**Your BudgetTracker is now fully functional! 🚀** 
+**Your Nudge is now fully functional! 🚀**

--- a/e2e/journeys/user-onboarding.spec.ts
+++ b/e2e/journeys/user-onboarding.spec.ts
@@ -27,7 +27,7 @@ test.describe('User Onboarding Journey', () => {
     await expect(page.locator('[data-testid="success-message"]')).toBeVisible()
 
     // Step 3: Onboarding Flow - Welcome
-    await expect(page.locator('h2')).toContainText('Welcome to BudgetTracker, John Doe!')
+    await expect(page.locator('h2')).toContainText('Welcome to Nudge, John Doe!')
     
     const continueButton = page.locator('button:has-text("Get Started")')
     await continueButton.click()

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="BudgetTracker" />
-    <meta name="application-name" content="BudgetTracker" />
+    <meta name="apple-mobile-web-app-title" content="Nudge" />
+    <meta name="application-name" content="Nudge" />
     <meta name="theme-color" content="#2563eb" />
     <meta name="msapplication-TileColor" content="#2563eb" />
     
@@ -45,7 +45,7 @@
       }
     </style>
     
-    <title>BudgetTracker - Your Financial Command Center</title>
+    <title>Nudge - Your Financial Command Center</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -53,14 +53,13 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
     }
   ];
 
-  const benefits = [
-    'Complete financial visibility in one dashboard',
-    'Automated expense categorization and insights',
-    'Multi-user household budget management',
-    'Real-time goal tracking and progress alerts',
-    'Secure bank-level encryption for all data',
-    'Mobile-responsive design for on-the-go access'
-  ];
+    const benefits = [
+      'Complete financial visibility in one dashboard',
+      'Automated expense categorization and insights',
+      'Multi-user household budget management',
+      'Real-time goal tracking and progress alerts',
+      'Mobile-responsive design for on-the-go access'
+    ];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
@@ -70,7 +69,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center">
               <BarChart3 className="h-8 w-8 text-blue-600" />
-              <span className="ml-2 text-xl font-bold text-gray-900">BudgetTracker</span>
+              <span className="ml-2 text-xl font-bold text-gray-900">Nudge</span>
             </div>
             <button
               onClick={onGetStarted}
@@ -102,9 +101,6 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
               Start Your Financial Journey
               <ArrowRight className="h-5 w-5" />
             </button>
-            <button className="border-2 border-gray-300 hover:border-gray-400 text-gray-700 px-8 py-4 rounded-lg font-semibold text-lg transition-colors">
-              Watch Demo
-            </button>
           </div>
 
           {/* Quick Stats */}
@@ -133,7 +129,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
               Everything You Need to Manage Your Money
             </h2>
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-              From daily expenses to long-term investments, BudgetTracker provides 
+              From daily expenses to long-term investments, Nudge provides
               comprehensive tools for every aspect of your financial life.
             </p>
           </div>
@@ -223,10 +219,10 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
               <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">
-                Why Choose BudgetTracker?
+                Why Choose Nudge?
               </h2>
               <p className="text-lg text-gray-600 mb-8">
-                Built by financial experts for real people, BudgetTracker combines 
+                Built by financial experts for real people, Nudge combines
                 powerful analytics with simple, intuitive design.
               </p>
               
@@ -246,17 +242,13 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
                 <p className="text-blue-100 mb-6">
                   Join thousands of users who have taken control of their financial future.
                 </p>
-                <div className="space-y-3">
-                  <div className="flex items-center gap-3">
-                    <Shield className="h-5 w-5 text-blue-200" />
-                    <span className="text-sm">Bank-level security</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <Smartphone className="h-5 w-5 text-blue-200" />
-                    <span className="text-sm">Works on all devices</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <Users className="h-5 w-5 text-blue-200" />
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-3">
+                      <Smartphone className="h-5 w-5 text-blue-200" />
+                      <span className="text-sm">Works on all devices</span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <Users className="h-5 w-5 text-blue-200" />
                     <span className="text-sm">Multi-user support</span>
                   </div>
                 </div>
@@ -291,10 +283,10 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           <div className="flex flex-col md:flex-row justify-between items-center">
             <div className="flex items-center mb-4 md:mb-0">
               <BarChart3 className="h-8 w-8 text-blue-400" />
-              <span className="ml-2 text-xl font-bold">BudgetTracker</span>
+              <span className="ml-2 text-xl font-bold">Nudge</span>
             </div>
             <div className="text-gray-400 text-sm">
-              © 2024 BudgetTracker. Take control of your financial future.
+              © 2024 Nudge. Take control of your financial future.
             </div>
           </div>
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -75,7 +75,7 @@ const Layout: React.FC<LayoutProps> = ({ children, activeTab, onTabChange }) => 
           <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
             <div className="flex flex-shrink-0 items-center px-4">
               <BarChart3 className="h-8 w-8 text-blue-600" />
-              <span className="ml-2 text-xl font-bold text-gray-900">BudgetTracker</span>
+              <span className="ml-2 text-xl font-bold text-gray-900">Nudge</span>
             </div>
             
             {/* User Profile */}
@@ -123,7 +123,7 @@ const Layout: React.FC<LayoutProps> = ({ children, activeTab, onTabChange }) => 
         <div className="flex items-center justify-between bg-white px-4 py-3 border-b border-gray-200">
           <div className="flex items-center">
             <BarChart3 className="h-7 w-7 text-blue-600" />
-            <span className="ml-2 text-lg font-bold text-gray-900">BudgetTracker</span>
+            <span className="ml-2 text-lg font-bold text-gray-900">Nudge</span>
           </div>
           
           <div className="flex items-center gap-3">

--- a/src/components/SupabaseStatusNotification.tsx
+++ b/src/components/SupabaseStatusNotification.tsx
@@ -31,7 +31,7 @@ const SupabaseStatusNotification: React.FC = () => {
               </h3>
               <div className="mt-1 text-sm text-amber-700">
                 <p className="mb-2">
-                  You're currently using BudgetTracker in demo mode. Your data won't be saved permanently.
+                  You're currently using Nudge in demo mode. Your data won't be saved permanently.
                 </p>
                 <div className="space-y-1">
                   <p className="font-medium">To enable full functionality:</p>

--- a/src/components/auth/OnboardingFlow.tsx
+++ b/src/components/auth/OnboardingFlow.tsx
@@ -31,7 +31,7 @@ const OnboardingFlow: React.FC = () => {
   const steps = [
     {
       id: 1,
-      title: 'Welcome to BudgetTracker',
+      title: 'Welcome to Nudge',
       subtitle: 'Let\'s set up your financial profile',
     },
     {
@@ -330,7 +330,7 @@ const OnboardingFlow: React.FC = () => {
       </div>
       
       <h2 className="text-2xl font-bold text-gray-900 mb-4">
-        Welcome to BudgetTracker, {profile?.full_name}!
+        Welcome to Nudge, {profile?.full_name}!
       </h2>
       
       <p className="text-gray-600 mb-8 max-w-md mx-auto">

--- a/src/utils/recurringTransactions.ts
+++ b/src/utils/recurringTransactions.ts
@@ -168,7 +168,7 @@ export const validateRecurringTransaction = (recurring: Partial<RecurringTransac
 /**
  * Local storage key for recurring transactions
  */
-const STORAGE_KEY = 'budgettracker_recurring_transactions';
+const STORAGE_KEY = 'nudge_recurring_transactions';
 
 /**
  * Save recurring transactions to local storage

--- a/supabase_complete_setup.sql
+++ b/supabase_complete_setup.sql
@@ -1,8 +1,8 @@
 /*
-  # Comprehensive Budgeter Application Database Setup
+  # Comprehensive Nudge Application Database Setup
   
   This script creates all necessary tables, indexes, RLS policies, and triggers
-  for the budgeter personal finance application.
+  for the Nudge personal finance application.
   
   Run this script in your new Supabase SQL editor to set up the complete database.
 */


### PR DESCRIPTION
## Summary
- rename the application to **Nudge** across the codebase
- remove the "Watch Demo" button from the landing page
- drop the "Bank-level security" reference
- adjust storage key to use `nudge_recurring_transactions`

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883660390bc832ab13dab02d4ab28b0