### PR TITLE
Fix signup link on login form

### DIFF
--- a/src/components/auth/AuthPage.tsx
+++ b/src/components/auth/AuthPage.tsx
@@ -42,7 +42,11 @@ const AuthPage: React.FC<AuthPageProps> = ({ onBackToLanding }) => {
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          {isLogin ? <LoginForm /> : <RegisterForm />}
+          {isLogin ? (
+            <LoginForm onSwitchToRegister={() => setIsLogin(false)} />
+          ) : (
+            <RegisterForm onSwitchToLogin={() => setIsLogin(true)} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -146,7 +146,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister }) => {
               className="text-blue-600 hover:text-blue-700 font-medium"
               disabled={loading}
             >
-              Create account
+              Sign up
             </button>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- update login page 'Create account' link text to 'Sign up'
- wire up callbacks in AuthPage so signup/signin links work

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883687554b0832aad1cec51f04d7d3b