### PR TITLE
Improve onboarding defaults and budgeting tools

### DIFF
--- a/src/components/BudgetEditor.tsx
+++ b/src/components/BudgetEditor.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { useFinanceData } from '../hooks/useFinanceData';
+
+/**
+ * Component for editing an existing monthly budget.  It allows users to
+ * update the total budget and reallocate funds across categories.  The
+ * component uses the updateBudget helper from useFinanceData.
+ */
+const BudgetEditor: React.FC<{ budgetId: string; onClose: () => void }> = ({ budgetId, onClose }) => {
+  const { budgets, budgetCategories, updateBudget } = useFinanceData();
+  const [totalAmount, setTotalAmount] = useState('');
+  const [categories, setCategories] = useState<{ category: string; allocated: string }[]>([]);
+
+  useEffect(() => {
+    const budget = budgets.find((b) => b.id === budgetId);
+    if (budget) {
+      setTotalAmount(budget.totalBudget.toString());
+      const cats = budgetCategories.filter((c) => c.budgetId === budget.id);
+      setCategories(cats.map((c) => ({ category: c.category, allocated: c.allocatedAmount.toString() })));
+    }
+  }, [budgetId, budgets, budgetCategories]);
+
+  const handleCategoryChange = (index: number, field: string, value: string) => {
+    setCategories((prev) => prev.map((c, i) => (i === index ? { ...c, [field]: value } : c)));
+  };
+
+  const handleAddCategory = () => {
+    setCategories((prev) => [...prev, { category: '', allocated: '' }]);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsedTotal = parseFloat(totalAmount);
+    if (isNaN(parsedTotal) || parsedTotal <= 0) {
+      alert('Please enter a valid total budget');
+      return;
+    }
+    const categoryBreakdown = categories
+      .filter((c) => c.category.trim())
+      .map((c) => ({ category: c.category.trim(), allocatedAmount: parseFloat(c.allocated) || 0 }));
+    try {
+      await updateBudget(budgetId, parsedTotal, categoryBreakdown);
+      onClose();
+    } catch (error) {
+      console.error('Error updating budget:', error);
+    }
+  };
+
+  return (
+    <div className="p-4 border border-gray-200 rounded">
+      <h3 className="text-lg font-semibold mb-2">Edit Budget</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="budget-total" className="block text-sm font-medium text-gray-700">Total Budget (€)</label>
+          <input
+            id="budget-total"
+            type="number"
+            min="0"
+            step="0.01"
+            value={totalAmount}
+            onChange={(e) => setTotalAmount(e.target.value)}
+            className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <div className="flex justify-between items-center">
+            <span className="font-medium">Categories</span>
+            <button type="button" onClick={handleAddCategory} className="text-blue-600 hover:underline">Add</button>
+          </div>
+          {categories.map((cat, idx) => (
+            <div key={idx} className="grid grid-cols-2 gap-2">
+              <input
+                type="text"
+                placeholder="Category"
+                value={cat.category}
+                onChange={(e) => handleCategoryChange(idx, 'category', e.target.value)}
+                className="border border-gray-300 rounded p-2"
+              />
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="Allocated (€)"
+                value={cat.allocated}
+                onChange={(e) => handleCategoryChange(idx, 'allocated', e.target.value)}
+                className="border border-gray-300 rounded p-2"
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default BudgetEditor;
+

--- a/src/components/RecurringExpensesManager.tsx
+++ b/src/components/RecurringExpensesManager.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from 'react';
+import { useFinanceData } from '../hooks/useFinanceData';
+import { Plus, Edit3, Trash2 } from 'lucide-react';
+
+/**
+ * Component for managing recurring expenses.  It displays a list of all recurring
+ * expenses and provides forms to add new ones or edit existing ones.  This
+ * component uses the recurring expense helpers provided by useFinanceData and
+ * relies on localStorage for persistence until a Supabase table is implemented.
+ */
+const RecurringExpensesManager: React.FC = () => {
+  const {
+    recurringExpenses,
+    addRecurringExpense,
+    updateRecurringExpense,
+    deleteRecurringExpense,
+  } = useFinanceData();
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formData, setFormData] = useState({
+    description: '',
+    amount: '',
+    category: '',
+    frequency: 'monthly',
+    nextDue: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const amount = parseFloat(formData.amount);
+    if (!formData.description.trim() || isNaN(amount) || amount <= 0) {
+      alert('Please enter a valid description and amount');
+      return;
+    }
+    const payload = {
+      id: editingId || Date.now().toString(),
+      description: formData.description.trim(),
+      amount,
+      category: formData.category || 'Other',
+      frequency: formData.frequency,
+      nextDue: formData.nextDue || new Date().toISOString().substring(0, 10),
+    };
+    try {
+      if (editingId) {
+        await updateRecurringExpense(editingId, payload);
+      } else {
+        await addRecurringExpense(payload);
+      }
+      setEditingId(null);
+      setFormData({ description: '', amount: '', category: '', frequency: 'monthly', nextDue: '' });
+      setShowForm(false);
+    } catch (error) {
+      console.error('Error saving recurring expense:', error);
+    }
+  };
+
+  const handleEdit = (id: string) => {
+    const exp = recurringExpenses.find((e) => e.id === id);
+    if (!exp) return;
+    setEditingId(id);
+    setFormData({
+      description: exp.description,
+      amount: exp.amount.toString(),
+      category: exp.category,
+      frequency: exp.frequency,
+      nextDue: exp.nextDue,
+    });
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Delete this recurring expense?')) {
+      await deleteRecurringExpense(id);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h2 className="text-xl font-semibold mb-4">Recurring Expenses</h2>
+      <button
+        type="button"
+        onClick={() => {
+          setEditingId(null);
+          setFormData({ description: '', amount: '', category: '', frequency: 'monthly', nextDue: '' });
+          setShowForm(true);
+        }}
+        className="mb-4 flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+      >
+        <Plus size={16} /> Add Recurring Expense
+      </button>
+      {showForm && (
+        <form onSubmit={handleSubmit} className="space-y-4 mb-6 border border-gray-200 p-4 rounded">
+          <div>
+            <label htmlFor="rec-description" className="block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="rec-description"
+              type="text"
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="rec-amount" className="block text-sm font-medium text-gray-700">Amount (€)</label>
+            <input
+              id="rec-amount"
+              type="number"
+              min="0"
+              step="0.01"
+              value={formData.amount}
+              onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="rec-category" className="block text-sm font-medium text-gray-700">Category</label>
+            <input
+              id="rec-category"
+              type="text"
+              value={formData.category}
+              onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            />
+          </div>
+          <div>
+            <label htmlFor="rec-frequency" className="block text-sm font-medium text-gray-700">Frequency</label>
+            <select
+              id="rec-frequency"
+              value={formData.frequency}
+              onChange={(e) => setFormData({ ...formData, frequency: e.target.value })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            >
+              <option value="monthly">Monthly</option>
+              <option value="weekly">Weekly</option>
+              <option value="yearly">Yearly</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="rec-nextdue" className="block text-sm font-medium text-gray-700">Next Due Date</label>
+            <input
+              id="rec-nextdue"
+              type="date"
+              value={formData.nextDue}
+              onChange={(e) => setFormData({ ...formData, nextDue: e.target.value })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              {editingId ? 'Update' : 'Add'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowForm(false);
+                setEditingId(null);
+              }}
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+      <ul className="space-y-2">
+        {recurringExpenses.map((exp) => (
+          <li key={exp.id} className="flex items-center justify-between p-2 border border-gray-200 rounded">
+            <div>
+              <div className="font-medium">{exp.description}</div>
+              <div className="text-sm text-gray-600">€{exp.amount.toLocaleString()} – {exp.frequency} – Next: {exp.nextDue}</div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => handleEdit(exp.id)}
+                className="p-1 text-gray-400 hover:text-blue-600"
+                title="Edit"
+              >
+                <Edit3 size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(exp.id)}
+                className="p-1 text-gray-400 hover:text-red-600"
+                title="Delete"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RecurringExpensesManager;
+


### PR DESCRIPTION
## Summary
- hydrate OnboardingFlow with existing profile data and relax income validation
- simplify balance validation for initial accounts
- fix allocateToAccount logic and update local state
- add recurring expense management helpers and UI
- allow editing monthly budgets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68837d6c5cc0832a8ead8fb987de059e