### PR TITLE
Fix onboarding state persistence

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -518,7 +518,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#06B6D4'];
           
           const accountsToInsert = data.accounts
-            .filter(account => account.name.trim() && account.balance.trim())
+            .filter(account => account.name.trim())
             .map((account, index) => ({
               user_id: user.id,
               name: account.name.trim(),
@@ -533,7 +533,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           if (accountsToInsert.length > 0) {
             const { data: accountsResult, error: accountsError } = await supabase
               .from('accounts')
-              .insert(accountsToInsert)
+              .upsert(accountsToInsert, {
+                onConflict: 'user_id,name'
+              })
               .select();
 
             if (accountsError) {

--- a/src/hooks/useFinanceData.ts
+++ b/src/hooks/useFinanceData.ts
@@ -1291,5 +1291,6 @@ export const useFinanceData = () => {
     monthlySavings,
     savingsRate,
     insights,
+    initializeData,
   };
 };


### PR DESCRIPTION
## Summary
- prefill onboarding inputs from the current profile once loaded
- reload finance data after onboarding completes
- allow account creation when balance empty and upsert accounts
- expose initializeData from `useFinanceData`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68838680ca0c832aaded47f40e39e546