### PR TITLE
Implement lump sum allocations

### DIFF
--- a/src/components/Users.tsx
+++ b/src/components/Users.tsx
@@ -164,7 +164,14 @@ const Users: React.FC = () => {
       return;
     }
 
-    allocateToAccount(selectedAccount.id, amount, allocationData.description);
+    const lumpSum = parseFloat(allocationData.cliffAmount);
+
+    allocateToAccount(
+      selectedAccount.id,
+      amount,
+      allocationData.description,
+      isNaN(lumpSum) ? undefined : lumpSum,
+    );
     
     setAllocationData({ amount: '', description: '', cliffAmount: '', cliffPeriod: '6' });
     setSelectedAccount(null);

--- a/src/hooks/useFinanceData.ts
+++ b/src/hooks/useFinanceData.ts
@@ -814,14 +814,22 @@ export const useFinanceData = () => {
   }, [user]);
 
   const allocateToAccount = useCallback(
-    async (accountId: string, amount: number, description?: string) => {
+    async (
+      accountId: string,
+      amount: number,
+      description?: string,
+      lumpSum?: number,
+    ) => {
       if (!user) return;
 
       try {
         // look up the current balance from local state
         const target = accounts.find((acc) => acc.id === accountId);
         const currentBalance = target ? target.balance : 0;
-        const newBalance = currentBalance + amount;
+
+        // Include optional lump sum if provided
+        const totalAmount = lumpSum ? amount + lumpSum : amount;
+        const newBalance = currentBalance + totalAmount;
 
         // Persist the updated balance to Supabase.  Because Supabase does not
         // support arithmetic expressions via the `.update()` helper, compute


### PR DESCRIPTION
## Summary
- allow allocation helper to accept lump sum
- handle optional lump sum in deposit modal

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68838852525c832a8adef267f1162be5